### PR TITLE
feat(CLAV-172): add breakpoint specific classes

### DIFF
--- a/css/grid-system.css
+++ b/css/grid-system.css
@@ -1,48 +1,56 @@
 .grid-container {
-  padding-left: var(--grid-mobile-gutter);
-  padding-right: var(--grid-mobile-gutter);
+	padding-left: var(--grid-mobile-gutter);
+	padding-right: var(--grid-mobile-gutter);
 }
 
 .grid {
-  --columns: var(--grid-mobile-column);
-  --column-gap: var(--grid-mobile-gutter);
+	--columns: var(--grid-mobile-column);
+	--column-gap: var(--grid-mobile-gutter);
 
-  display: grid;
-  grid-template-columns: repeat(var(--columns), 1fr);
-  width: 100%;
-  column-gap: var(--column-gap);
+	display: grid;
+	grid-template-columns: repeat(var(--columns), 1fr);
+	width: 100%;
+	column-gap: var(--column-gap);
 }
 
-.col-span-full {
-  grid-column: 1 / -1;
+.col-1 {
+	grid-column: span 1 / span 1;
 }
 
-.col-sm-4 {
-  grid-column: span 4 / span 4;
+.col-2 {
+	grid-column: span 2 / span 2;
 }
 
-.col-sm-3 {
-  grid-column: span 3 / span 3;
+.col-3 {
+	grid-column: span 3 / span 3;
 }
 
-.col-sm-2 {
-  grid-column: span 2 / span 2;
-}
-
-.col-sm-1 {
-  grid-column: span 1 / span 1;
+.col-4,
+.col-5,
+.col-6,
+.col-7,
+.col-8,
+.col-9,
+.col-10,
+.col-11,
+.col-12 {
+	grid-column: span 4 / span 4;
 }
 
 .col-start-1 {
-  grid-column-start: 1;
+	grid-column-start: 1;
 }
 
 .col-start-2 {
-  grid-column-start: 2;
+	grid-column-start: 2;
 }
 
 .col-start-3 {
-  grid-column-start: 3;
+	grid-column-start: 3;
+}
+
+.col-start-4 {
+	grid-column-start: 4;
 }
 
 .col-start-4,
@@ -54,363 +62,400 @@
 .col-start-10,
 .col-start-11,
 .col-start-12 {
-  grid-column-start: 4;
+	grid-column-start: 4;
 }
 
-/*
-    .col-start-rev-1 is intentionally missing
-    because `grid-column-start: -1` will place the item after the last column,
-    breaking the grid
-  */
-
-.col-start-rev-2 {
-  grid-column-start: -2;
+.col-sm-1 {
+	grid-column: span 1 / span 1;
 }
 
-.col-start-rev-3 {
-  grid-column-start: -3;
+.col-sm-2 {
+	grid-column: span 2 / span 2;
 }
 
-.col-start-rev-4 {
-  grid-column-start: -4;
+.col-sm-3 {
+	grid-column: span 3 / span 3;
 }
 
-.col-start-rev-5,
-.col-start-rev-6,
-.col-start-rev-7,
-.col-start-rev-8,
-.col-start-rev-9,
-.col-start-rev-10,
-.col-start-rev-11,
-.col-start-rev-12,
-.col-start-rev-13 {
-  grid-column-start: -5;
+.col-sm-4 {
+	grid-column: span 4 / span 4;
 }
 
-.col-end-last {
-  grid-column-end: -1;
+.col-sm-start-1 {
+	grid-column-start: 1;
 }
 
-/*
-    .col-end-1 is intentionally missing:
-    since `grid-column-end: <n>` means "end this column where column <n> start"
-    and not "end this column where column <n> end",
-    `grid-column-end: 1` means "end this column where column 1 start"
-    that will break things up and doesn't even make any sense IMHO.
-  */
-
-.col-end-2 {
-  grid-column-end: 2;
+.col-sm-start-2 {
+	grid-column-start: 2;
 }
 
-.col-end-3 {
-  grid-column-end: 3;
+.col-sm-start-3 {
+	grid-column-start: 3;
 }
 
-.col-end-4 {
-  grid-column-end: 4;
-}
-
-/*
-    NB: this means "end this column where column 5 start",
-    which is the same as saying "end this column where column 4 end"
-  */
-.col-end-5,
-.col-end-6,
-.col-end-7,
-.col-end-8,
-.col-end-9,
-.col-end-10,
-.col-end-11,
-.col-end-12,
-.col-end-13 {
-  grid-column-end: 5;
-}
-
-.col-end-rev-1 {
-  grid-column-end: -1;
-}
-
-.col-end-rev-2 {
-  grid-column-end: -2;
-}
-
-.col-end-rev-3 {
-  grid-column-end: -3;
-}
-
-.col-end-rev-4,
-.col-end-rev-5,
-.col-end-rev-6,
-.col-end-rev-7,
-.col-end-rev-8,
-.col-end-rev-9,
-.col-end-rev-10,
-.col-end-rev-11,
-.col-end-rev-12 {
-  grid-column-end: -4;
+.col-sm-start-4 {
+	grid-column-start: 4;
 }
 
 @media (min-width: 768px) {
-  .grid-container {
-    padding-left: var(--grid-tablet-gutter);
-    padding-right: var(--grid-tablet-gutter);
-  }
+	.grid-container {
+		padding-left: var(--grid-tablet-gutter);
+		padding-right: var(--grid-tablet-gutter);
+	}
 
-  .grid {
-    --columns: var(--grid-tablet-column);
-    --column-gap: var(--grid-tablet-gutter);
-  }
+	.grid {
+		--columns: var(--grid-tablet-column);
+		--column-gap: var(--grid-tablet-gutter);
+	}
 
-  .col-md-1 {
-    grid-column: span 1 / span 1;
-  }
+	.col-5 {
+		grid-column: span 5 / span 5;
+	}
 
-  .col-md-2 {
-    grid-column: span 2 / span 2;
-  }
+	.col-6 {
+		grid-column: span 6 / span 6;
+	}
 
-  .col-md-3 {
-    grid-column: span 3 / span 3;
-  }
+	.col-7 {
+		grid-column: span 7 / span 7;
+	}
 
-  .col-md-4 {
-    grid-column: span 4 / span 4;
-  }
+	.col-8,
+	.col-9,
+	.col-10,
+	.col-11,
+	.col-12 {
+		grid-column: span 8 / span 8;
+	}
 
-  .col-md-5 {
-    grid-column: span 5 / span 5;
-  }
+	.col-start-5 {
+		grid-column-start: 5;
+	}
 
-  .col-md-6 {
-    grid-column: span 6 / span 6;
-  }
+	.col-start-6 {
+		grid-column-start: 6;
+	}
 
-  .col-md-7 {
-    grid-column: span 7 / span 7;
-  }
+	.col-start-7 {
+		grid-column-start: 7;
+	}
 
-  .col-md-8 {
-    grid-column: span 8 / span 8;
-  }
+	.col-start-8,
+	.col-start-9,
+	.col-start-10,
+	.col-start-11,
+	.col-start-12 {
+		grid-column-start: 8;
+	}
 
-  .col-start-5 {
-    grid-column-start: 5;
-  }
+	.col-md-1 {
+		grid-column: span 1 / span 1;
+	}
 
-  .col-start-6 {
-    grid-column-start: 6;
-  }
+	.col-md-2 {
+		grid-column: span 2 / span 2;
+	}
 
-  .col-start-7 {
-    grid-column-start: 7;
-  }
+	.col-md-3 {
+		grid-column: span 3 / span 3;
+	}
 
-  .col-start-8,
-  .col-start-9,
-  .col-start-10,
-  .col-start-11,
-  .col-start-12 {
-    grid-column-start: 8;
-  }
+	.col-md-4 {
+		grid-column: span 4 / span 4;
+	}
 
-  .col-start-rev-6 {
-    grid-column-start: -6;
-  }
+	.col-md-5 {
+		grid-column: span 5 / span 5;
+	}
 
-  .col-start-rev-7 {
-    grid-column-start: -7;
-  }
+	.col-md-6 {
+		grid-column: span 6 / span 6;
+	}
 
-  .col-start-rev-8 {
-    grid-column-start: -8;
-  }
+	.col-md-7 {
+		grid-column: span 7 / span 7;
+	}
 
-  .col-start-rev-9,
-  .col-start-rev-10,
-  .col-start-rev-11,
-  .col-start-rev-12,
-  .col-start-rev-13 {
-    grid-column-start: -9;
-  }
+	.col-md-8 {
+		grid-column: span 8 / span 8;
+	}
 
-  .col-end-6 {
-    grid-column-end: 6;
-  }
+	.col-md-start-1 {
+		grid-column-start: 1;
+	}
 
-  .col-end-7 {
-    grid-column-end: 7;
-  }
+	.col-md-start-2 {
+		grid-column-start: 2;
+	}
 
-  .col-end-8 {
-    grid-column-end: 8;
-  }
+	.col-md-start-3 {
+		grid-column-start: 3;
+	}
 
-  .col-end-9,
-  .col-end-10,
-  .col-end-11,
-  .col-end-12,
-  .col-end-13 {
-    grid-column-end: 9;
-  }
+	.col-md-start-4 {
+		grid-column-start: 4;
+	}
 
-  .col-end-rev-5 {
-    grid-column-end: -5;
-  }
+	.col-md-start-5 {
+		grid-column-start: 5;
+	}
 
-  .col-end-rev-6 {
-    grid-column-end: -6;
-  }
+	.col-md-start-6 {
+		grid-column-start: 6;
+	}
 
-  .col-end-rev-7 {
-    grid-column-end: -7;
-  }
+	.col-md-start-7 {
+		grid-column-start: 7;
+	}
 
-  .col-end-rev-8,
-  .col-end-rev-9,
-  .col-end-rev-10,
-  .col-end-rev-11,
-  .col-end-rev-12 {
-    grid-column-end: -8;
-  }
+	.col-md-start-8 {
+		grid-column-start: 8;
+	}
 }
 
 @media (min-width: 1152px) {
-  .grid-container {
-    padding-left: var(--grid-desktop-gutter);
-    padding-right: var(--grid-desktop-gutter);
-  }
+	.grid-container {
+		padding-left: var(--grid-desktop-gutter);
+		padding-right: var(--grid-desktop-gutter);
+	}
 
-  .grid {
-    --columns: var(--grid-desktop-column);
-    --column-gap: var(--grid-desktop-gutter);
-  }
+	.grid {
+		--columns: var(--grid-desktop-column);
+		--column-gap: var(--grid-desktop-gutter);
+	}
 
-  .col-xl-1 {
-    grid-column: span 1 / span 1;
-  }
+	.col-9 {
+		grid-column: span 9 / span 9;
+	}
 
-  .col-xl-2 {
-    grid-column: span 2 / span 2;
-  }
+	.col-10 {
+		grid-column: span 10 / span 10;
+	}
 
-  .col-xl-3 {
-    grid-column: span 3 / span 3;
-  }
+	.col-11 {
+		grid-column: span 11 / span 11;
+	}
 
-  .col-xl-4 {
-    grid-column: span 4 / span 4;
-  }
+	.col-12 {
+		grid-column: span 12 / span 12;
+	}
 
-  .col-xl-5 {
-    grid-column: span 5 / span 5;
-  }
+	.col-start-9 {
+		grid-column-start: 9;
+	}
+	.col-start-10 {
+		grid-column-start: 10;
+	}
 
-  .col-xl-6 {
-    grid-column: span 6 / span 6;
-  }
+	.col-start-11 {
+		grid-column-start: 11;
+	}
 
-  .col-xl-7 {
-    grid-column: span 7 / span 7;
-  }
+	.col-start-12 {
+		grid-column-start: 12;
+	}
 
-  .col-xl-8 {
-    grid-column: span 8 / span 8;
-  }
+	.col-lg-1 {
+		grid-column: span 1 / span 1;
+	}
 
-  .col-xl-9 {
-    grid-column: span 9 / span 9;
-  }
+	.col-lg-2 {
+		grid-column: span 2 / span 2;
+	}
 
-  .col-xl-10 {
-    grid-column: span 1 / span 10;
-  }
+	.col-lg-3 {
+		grid-column: span 3 / span 3;
+	}
 
-  .col-xl-11 {
-    grid-column: span 1 / span 11;
-  }
+	.col-lg-4 {
+		grid-column: span 4 / span 4;
+	}
 
-  .col-xl-12 {
-    grid-column: span 1 / span 12;
-  }
+	.col-lg-5 {
+		grid-column: span 5 / span 5;
+	}
 
-  .col-start-9 {
-    grid-column-start: 9;
-  }
+	.col-lg-6 {
+		grid-column: span 6 / span 6;
+	}
 
-  .col-start-10 {
-    grid-column-start: 10;
-  }
+	.col-lg-7 {
+		grid-column: span 7 / span 7;
+	}
 
-  .col-start-11 {
-    grid-column-start: 11;
-  }
+	.col-lg-8 {
+		grid-column: span 8 / span 8;
+	}
 
-  .col-start-12 {
-    grid-column-start: 12;
-  }
+	.col-lg-9 {
+		grid-column: span 9 / span 9;
+	}
 
-  .col-start-rev-10 {
-    grid-column-start: -10;
-  }
+	.col-lg-10 {
+		grid-column: span 10 / span 10;
+	}
 
-  .col-start-rev-11 {
-    grid-column-start: -11;
-  }
+	.col-lg-11 {
+		grid-column: span 11 / span 11;
+	}
 
-  .col-start-rev-12 {
-    grid-column-start: -12;
-  }
+	.col-lg-12 {
+		grid-column: span 12 / span 12;
+	}
 
-  .col-start-rev-13 {
-    grid-column-start: -13;
-  }
+	.col-lg-start-1 {
+		grid-column-start: 1;
+	}
 
-  .col-end-10 {
-    grid-column-end: 10;
-  }
+	.col-lg-start-2 {
+		grid-column-start: 2;
+	}
 
-  .col-end-11 {
-    grid-column-end: 11;
-  }
+	.col-lg-start-3 {
+		grid-column-start: 3;
+	}
 
-  .col-end-12 {
-    grid-column-end: 12;
-  }
+	.col-lg-start-4 {
+		grid-column-start: 4;
+	}
 
-  .col-end-13 {
-    grid-column-end: 13;
-  }
+	.col-lg-start-5 {
+		grid-column-start: 5;
+	}
 
-  .col-end-rev-9 {
-    grid-column-end: -9;
-  }
+	.col-lg-start-6 {
+		grid-column-start: 6;
+	}
 
-  .col-end-rev-10 {
-    grid-column-end: -10;
-  }
+	.col-lg-start-7 {
+		grid-column-start: 7;
+	}
 
-  .col-end-rev-11 {
-    grid-column-end: -11;
-  }
+	.col-lg-start-8 {
+		grid-column-start: 8;
+	}
 
-  .col-end-rev-12 {
-    grid-column-end: -12;
-  }
+	.col-lg-start-9 {
+		grid-column-start: 9;
+	}
+
+	.col-lg-start-10 {
+		grid-column-start: 10;
+	}
+
+	.col-lg-start-11 {
+		grid-column-start: 11;
+	}
+
+	.col-lg-start-12 {
+		grid-column-start: 12;
+	}
 }
 
 @media (min-width: 1366px) {
-  .grid-container {
-    padding-left: var(--grid-wide-gutter);
-    padding-right: var(--grid-wide-gutter);
-  }
+	.grid-container {
+		padding-left: var(--grid-wide-gutter);
+		padding-right: var(--grid-wide-gutter);
+	}
 
-  .grid {
-    --columns: var(--grid-wide-column);
-    --column-gap: var(--grid-wide-gutter);
-  }
+	.grid {
+		--columns: var(--grid-wide-column);
+		--column-gap: var(--grid-wide-gutter);
+	}
 
-  .col-span-large-4 {
-    grid-column: span 4;
-  }
+	.col-xl-1 {
+		grid-column: span 1 / span 1;
+	}
+
+	.col-xl-2 {
+		grid-column: span 2 / span 2;
+	}
+
+	.col-xl-3 {
+		grid-column: span 3 / span 3;
+	}
+
+	.col-xl-4 {
+		grid-column: span 4 / span 4;
+	}
+
+	.col-xl-5 {
+		grid-column: span 5 / span 5;
+	}
+
+	.col-xl-6 {
+		grid-column: span 6 / span 6;
+	}
+
+	.col-xl-7 {
+		grid-column: span 7 / span 7;
+	}
+
+	.col-xl-8 {
+		grid-column: span 8 / span 8;
+	}
+
+	.col-xl-9 {
+		grid-column: span 9 / span 9;
+	}
+
+	.col-xl-10 {
+		grid-column: span 10 / span 10;
+	}
+
+	.col-xl-11 {
+		grid-column: span 11 / span 11;
+	}
+
+	.col-xl-12 {
+		grid-column: span 12 / span 12;
+	}
+
+	.col-xl-start-1 {
+		grid-column-start: 1;
+	}
+
+	.col-xl-start-2 {
+		grid-column-start: 2;
+	}
+
+	.col-xl-start-3 {
+		grid-column-start: 3;
+	}
+
+	.col-xl-start-4 {
+		grid-column-start: 4;
+	}
+
+	.col-xl-start-5 {
+		grid-column-start: 5;
+	}
+
+	.col-xl-start-6 {
+		grid-column-start: 6;
+	}
+
+	.col-xl-start-7 {
+		grid-column-start: 7;
+	}
+
+	.col-xl-start-8 {
+		grid-column-start: 8;
+	}
+
+	.col-xl-start-9 {
+		grid-column-start: 9;
+	}
+
+	.col-xl-start-10 {
+		grid-column-start: 10;
+	}
+
+	.col-xl-start-11 {
+		grid-column-start: 11;
+	}
+
+	.col-xl-start-12 {
+		grid-column-start: 12;
+	}
 }

--- a/example/index.html
+++ b/example/index.html
@@ -8,7 +8,7 @@
       href="https://unpkg.com/@zanichelli/albe-design-tokens/dist/tokens.css"
     />
     <link rel="stylesheet" media="screen" href="../css/grid-system.css" />
-    <link rel="icon" type="image/x-icon" href="../asssets/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
     <style>
       * {
         font-family: var(--font-family-sans);
@@ -36,7 +36,6 @@
         background-color: var(--accent-lighter);
         text-align: center;
         font-size: 14px;
-        margin: 4px 0;
         overflow-x: auto;
       }
       @media (min-width: 768px) {
@@ -61,21 +60,7 @@
   <body>
     <h1>Zanichelli Grid System</h1>
     <div class="container desktop">
-      <h3>Desktop</h3>
-      <div class="grid">
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-        <div class="col-xl-1">col-xl-1</div>
-      </div>
+      <h3>Large Desktop</h3>
       <div class="grid">
         <div class="col-xl-3">col-xl-3</div>
         <div class="col-xl-3">col-xl-3</div>
@@ -93,18 +78,28 @@
       </div>
     </div>
 
+    <div class="container desktop">
+      <h3>Small Desktop</h3>
+        <div class="grid">
+          <div class="col-lg-3">col-lg-3</div>
+          <div class="col-lg-3">col-lg-3</div>
+          <div class="col-lg-3">col-lg-3</div>
+          <div class="col-lg-3">col-lg-3</div>
+        </div>
+        <div class="grid">
+          <div class="col-lg-4">col-lg-4</div>
+          <div class="col-lg-4">col-lg-4</div>
+          <div class="col-lg-4">col-lg-4</div>
+        </div>
+        <div class="grid">
+          <div class="col-lg-6">col-lg-6</div>
+          <div class="col-lg-6">col-lg-6</div>
+        </div>
+      </div>
+    </div>
+
     <div class="container tablet">
       <h3>Tablet</h3>
-      <div class="grid">
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-        <div class="col-md-1">col-md-1</div>
-      </div>
       <div class="grid">
         <div class="col-md-3">col-md-3</div>
         <div class="col-md-3">col-md-3</div>
@@ -123,39 +118,31 @@
     <div class="container">
       <h3>Mixed</h3>
       <div class="grid">
-        <div class="col-xl-6 col-md-4">col-xl-6 col-md-4</div>
-        <div class="col-xl-6 col-md-4">col-xl-6 col-md-4</div>
+        <div class="col-4 col-md-4 col-lg-6">col-6 col-md-4 col-lg-6</div>
+        <div class="col-4 col-md-4 col-lg-6">col-6 col-md-4 col-lg-6</div>
       </div>
       <div class="grid">
-        <div class="col-sm-4 col-xl-5">col-sm-4 col-xl-5</div>
-        <div class="col-sm-4 col-xl-5">col-sm-4 col-xl-5</div>
+        <div class="col-4 col-xl-6">col-4 col-xl-6</div>
+        <div class="col-4 col-xl-6">col-4 col-xl-6</div>
       </div>
       <div class="grid">
-        <div class="col-md-2 col-xl-6">col-xl-6 col-md-2</div>
-        <div class="col-md-2 col-xl-6">col-xl-6 col-md-2</div>
-        <div class="col-xl-6 col-md-4 col-xl-2">col-xl-6 col-md-4 col-xl-2</div>
+        <div class="col-2 col-xl-6">col-2 col-xl-6</div>
+        <div class="col-2 col-xl-6">col-2 col-xl-6</div>
+        <div class="col-4 col-lg-6 col-start-1 col-lg-start-4">col-4 col-lg-6 col-start-1 col-lg-start-4</div>
       </div>
     </div>
 
     <div class="container">
       <h3>Nested</h3>
       <div class="grid">
-        <div class="col-sm-2 col-xl-3">col-sm-2 col-xl-3</div>
-        <div class="col-sm-4 col-md-6 col-xl-9">
-          <span>col-sm-4 col-md-6 col-xl-9</span>
+        <div class="col-4 col-md-2 col-lg-3">col-4 col-md-2 col-lg-3</div>
+        <div class="col-4 col-md-6 col-lg-9">
+          <span>col-4 col-md-6 col-lg-9</span>
           <div class="grid">
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
-            <div class="col-xl-1">col-xl-1</div>
+            <div class="col-1 col-md-2 col-lg-3">col-1 col-md-2 col-lg-3</div>
+            <div class="col-1 col-md-2 col-lg-3">col-1 col-md-2 col-lg-3</div>
+            <div class="col-1 col-md-2 col-lg-3">col-1 col-md-2 col-lg-3</div>
+            <div class="col-1 col-md-2 col-lg-3">col-1 col-md-2 col-lg-3</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation and Context
Related to [CLAV-172](https://zanichelli.atlassian.net/browse/CLAV-172), we must handle specific column widths and offsets, for different screen widths. 

With this PR we add/refactor the following classes

**Default**
`col-*` and `col-start-*`

**Small screens (< 767px)**
`col-sm-*` and `col-sm-start-*`

**Medium screens (> 768px)**
`col-md-*` and `col-md-start-*`

**Large screens (> 1152px)**
`col-lg-*` and `col-lg-start-*`

**Extra Large screens (> 1366px)**
`col-xl-*` and `col-xl-start-*`

**Bonus**
We remove `col-start-rev-*`, `col-end-*` and `col-end-rev-*`. The same result can be achieved using `col-start-*`

